### PR TITLE
Get Merged Individuals

### DIFF
--- a/src/ChurchCommunityBuilder.Api/ChurchCommunityBuilder.Api.csproj
+++ b/src/ChurchCommunityBuilder.Api/ChurchCommunityBuilder.Api.csproj
@@ -117,6 +117,8 @@
     <Compile Include="People\Entity\HowTheyHeardCollection.cs" />
     <Compile Include="People\Entity\Individual.cs" />
     <Compile Include="People\Entity\IndividualCollection.cs" />
+    <Compile Include="People\Entity\MergedIndividual.cs" />
+    <Compile Include="People\Entity\MergedIndividualCollection.cs" />
     <Compile Include="People\Entity\MobileCarrier.cs" />
     <Compile Include="People\Entity\MobileCarrierCollection.cs" />
     <Compile Include="People\Entity\Phone.cs" />
@@ -135,6 +137,7 @@
     <Compile Include="People\Sets\HowTheyHeard.cs" />
     <Compile Include="People\Sets\Individuals.cs" />
     <Compile Include="People\Sets\MembershipTypes.cs" />
+    <Compile Include="People\Sets\MergedIndividuals.cs" />
     <Compile Include="People\Sets\MobileCarriers.cs" />
     <Compile Include="People\Sets\UserDefinedFields.cs" />
     <Compile Include="Processes\Entity\ProcessIndividualCollection.cs" />

--- a/src/ChurchCommunityBuilder.Api/People/Entity/MergedIndividual.cs
+++ b/src/ChurchCommunityBuilder.Api/People/Entity/MergedIndividual.cs
@@ -1,0 +1,66 @@
+﻿/*######### NOTE: reason for DateMergedString ############
+CCB is known to sometimes return the following:
+   <date_merged>0000-00-00 00:00:00</date_merged>
+A valid mySQL date but not in .NET; outright fails serialization.
+####################################################### */
+
+using System;
+using System.Xml;
+using ChurchCommunityBuilder.Api.Entity;
+using System.Xml.Serialization;
+
+namespace ChurchCommunityBuilder.Api.People.Entity
+{
+    [XmlRoot("merged_individual")]
+    public class MergedIndividual
+    {
+
+        public MergedIndividual()
+        {
+            this.Creator = new Lookup();
+            this.Modifier = new Lookup();
+        }
+
+
+        [XmlElement("winner_id")]
+        public int WinnerID { get; set; }
+
+        [XmlElement("loser_id")]
+        public int LoserID { get; set; }
+
+        private DateTime? _dateMerged;
+
+        [XmlIgnore]
+        public DateTime? DateMerged
+        {
+            get { return _dateMerged; }
+            set { _dateMerged = value; }
+        }
+
+        [XmlElement("date_merged")]
+        public string DateMergedString
+        {
+            get
+            {
+                return _dateMerged.HasValue ? XmlConvert.ToString(_dateMerged.Value, XmlDateTimeSerializationMode.Unspecified): string.Empty;
+            }
+            set
+            {
+                _dateMerged = !string.IsNullOrEmpty(value) ? XmlConvert.ToDateTime(value, XmlDateTimeSerializationMode.Unspecified): (DateTime?)null;
+            }
+        }
+
+        [XmlElement("creator")]
+        public Lookup Creator { get; set; }
+
+        [XmlElement("modifier")]
+        public Lookup Modifier { get; set; }
+
+        [XmlElement("created")]
+        public DateTime? Created { get; set; }
+
+        [XmlElement("modified")]
+        public DateTime? Modified { get; set; }
+
+    }
+}

--- a/src/ChurchCommunityBuilder.Api/People/Entity/MergedIndividualCollection.cs
+++ b/src/ChurchCommunityBuilder.Api/People/Entity/MergedIndividualCollection.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using ChurchCommunityBuilder.Api.Entity;
+using System.Xml.Serialization;
+
+namespace ChurchCommunityBuilder.Api.People.Entity
+{
+
+    public class MergedIndividualCollection : Response
+    {
+
+        public MergedIndividualCollection()
+        {
+            this.MergedIndividuals = new List<MergedIndividual>();
+        }
+
+
+        [XmlArrayItem("merged_individual", typeof(MergedIndividual))]
+        [XmlArray("merged_individuals")]
+        public List<MergedIndividual> MergedIndividuals { get; set; }
+
+    }
+}

--- a/src/ChurchCommunityBuilder.Api/People/Sets/MergedIndividuals.cs
+++ b/src/ChurchCommunityBuilder.Api/People/Sets/MergedIndividuals.cs
@@ -15,7 +15,7 @@ namespace ChurchCommunityBuilder.Api.People.Sets {
         public MergedIndividualCollection List(DateTime modifiedSince)
         {
             var parameters = new Dictionary<string, string>();
-            parameters.Add("modified_since", modifiedSince.ToString());
+            parameters.Add("modified_since", modifiedSince.ToString("yyyy-MM-dd"));
             return this.Execute("merged_individuals", parameters);
         }
 

--- a/src/ChurchCommunityBuilder.Api/People/Sets/MergedIndividuals.cs
+++ b/src/ChurchCommunityBuilder.Api/People/Sets/MergedIndividuals.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using ChurchCommunityBuilder.Api.People.Entity;
+
+namespace ChurchCommunityBuilder.Api.People.Sets {
+
+    public class MergedIndividuals : BaseApiSet<MergedIndividualCollection> {
+        public MergedIndividuals(string baseUrl, string username, string password) : base(baseUrl, username, password) {}
+
+        public MergedIndividualCollection List()
+        {
+            return this.Execute("merged_individuals");
+        }
+
+        public MergedIndividualCollection List(DateTime modifiedSince)
+        {
+            var parameters = new Dictionary<string, string>();
+            parameters.Add("modified_since", modifiedSince.ToString());
+            return this.Execute("merged_individuals", parameters);
+        }
+
+    }
+}

--- a/src/ChurchCommunityBuilder.Api/Realms/PeopleRealm.cs
+++ b/src/ChurchCommunityBuilder.Api/Realms/PeopleRealm.cs
@@ -20,6 +20,7 @@ namespace ChurchCommunityBuilder.Api.Realms {
         private ChurchCommunityBuilder.Api.People.Sets.MobileCarriers _mobileCarrierSet;
         private ChurchCommunityBuilder.Api.People.Sets.UserDefinedFields _userDefinedFieldSet;
         private ChurchCommunityBuilder.Api.People.Sets.CustomFields _customFields;
+        private ChurchCommunityBuilder.Api.People.Sets.MergedIndividuals _mergedIndividualSet;
 
         #region Sets
         public ChurchCommunityBuilder.Api.People.Sets.Individuals Individuals {
@@ -111,6 +112,20 @@ namespace ChurchCommunityBuilder.Api.Realms {
                 return _customFields;
             }
         }
+
+        public ChurchCommunityBuilder.Api.People.Sets.MergedIndividuals MergedIndividuals
+        {
+            get
+            {
+                if (_mergedIndividualSet == null)
+                {
+                    _mergedIndividualSet = new People.Sets.MergedIndividuals(string.Format(API_URL, base.ChurchCode), base.UserName, base.Password);
+                }
+
+                return _mergedIndividualSet;
+            }
+        }
+
         #endregion Sets
     }
 }


### PR DESCRIPTION
Adds missing service - ability to use the **[merged_individuals](https://designccb.s3.amazonaws.com/helpdesk/files/official_docs/api.html#mergedindividuals)** service.

(The Merged Individuals service returns a list of all individuals that have been removed from the Church Community Builder system using the duplicate merge feature.)